### PR TITLE
Add CI build through RISC OS Build service.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.s gitlab-language=armasm linguist-language=assembly
+*.hdr gitlab-language=armasm linguist-language=assembly

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something that's not right about the project
+title: ''
+labels: bug
+assignees: 'gerph'
+
+---
+
+## Problem statement
+
+<!-- Explain what you think is wrong -->
+
+
+## Environment
+
+<!-- Give details about the environment in which you are running, for
+     example, the OS version, hardware, devices or applications that
+     are related to the issue -->
+
+
+## Expected result
+
+<!-- Explain what you expect to happen -->
+
+
+## Reproduction steps
+
+<!-- Explain how to reproduce, or which test the failure is in -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: 'gerph'
+
+---
+
+## Is your feature request related to a problem?
+
+<!-- Give a clear description of what you're trying to address with
+     this request.
+     For example, "I'm always frustrated when [...]",
+     "It is hard to [...]"
+  -->
+
+## Describe the solution you'd like
+
+<!-- Give a clear description of how you the request might be
+     addressed. If you have ideas about how it could be implemented,
+     separate them from user interface changes.
+  -->
+
+## Additional context
+
+<!-- If you have some context, like places where this would have
+     helped, screenshots or mock ups of an interface, or the sort
+     of results you'd like to see, include them here.
+  -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Changes
+
+<!-- Describe the changes you've made in this section.
+     Try to explain why they're needed and what they do.
+     Your reviewers will use this to decide whether the
+     change is sufficient and correct.
+     You can include pictures or diagrams in here
+     (see mermaid documentation on GitHub).
+ -->
+
+# Testing
+
+<!-- Describe the testing you have done manually to
+     satisfy yourself that the change works as intended.
+     If automated tests have been updated, state this.
+     Include output or pictures if necessary.
+ -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       # Step intended to be reused in CI pipelines.
       - name: Build through build.riscos.online

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+---
+# RISC OS CI build through build.riscos.online
+#
+# To reuse this configuration with your own repository:
+#
+#   - Create a .robuild.yaml to describe what should be built on RISC OS.
+#       - `jobs.build.script` should be a list of commands to run on RISC OS
+#       - `jobs.build.artifacts.path` should be the directory to zip.
+#   - Create a VersionNum file if you wish to use the automated versioning
+#     in the same style as the RISC OS sources. [optional]
+#   - Update the 3rd step ('give the archive a versioned name') to give a
+#     suitable name for the archive.
+#   - Update the 4th step ('upload-artifacts') to include the same names.
+#
+# The 'release' job is triggered when a tag starting with a 'v' is created,
+# which will create a GitHub release for the repository with the name of the
+# version tag. The release will be a draft, and should be updated with
+# changes as you see fit.
+#
+
+name: RISC OS
+
+# Controls when the action will run. Triggers the workflow on:
+#   * push on any branch.
+#   * tag creation for tags beginning with a 'v'
+on:
+  push:
+    branches: ["*"]
+    tags: ["v*"]
+  # Pull request events happen on pull request state transitions, so we probably don't want this here.
+  #pull_request:
+  #  branches: ["*"]
+
+jobs:
+  build-riscos:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      leafname: ${{ steps.version.outputs.leafname }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Step intended to be reused in CI pipelines.
+      - name: Build through build.riscos.online
+        run: |
+          set -o pipefail
+          # Zip up the source to send to robuild
+          zip -q9r /tmp/source-archive.zip * .robuild.yaml
+          # Fetch the build client
+          curl -s -L -o riscos-build-online https://github.com/gerph/robuild-client/releases/download/v0.05/riscos-build-online && chmod +x riscos-build-online
+          # Send the archive file to build service
+          ./riscos-build-online -i /tmp/source-archive.zip -t 60 -o /tmp/built
+      - name: Give the output a versioned name
+        id: version
+        run: |
+          if [[ -f VersionNum ]] ; then
+              version=$(sed '/MajorVersion / ! d ; s/.*MajorVersion *"\(.*\)"/\1/' VersionNum)
+          else
+              version=$(git rev-parse --short HEAD)
+          fi
+          echo "This is version: $version"
+          leafname="KeyMapper-$version.zip"
+          if [ -f /tmp/built,a91 ] ; then
+              cp /tmp/built,a91 "KeyMapper-$version.zip"
+          else
+              echo "No archive was built?"
+              exit 1
+          fi
+          echo "::set-output name=version::$version"
+          echo "::set-output name=leafname::$leafname"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: RISCOS-build
+          path: ${{ steps.version.outputs.leafname }}
+        # The artifact that is downloadable from the Actions is actually a zip of the artifacts
+        # that we supply. So it will be a regular Zip file containing a RISC OS Zip file.
+
+  # The release only triggers when the thing that was pushed was a tag starting with 'v'
+  release:
+    needs: build-riscos
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download built binary
+        uses: actions/download-artifact@v1
+        with:
+          name: RISCOS-build
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ needs.build-riscos.outputs.version }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`.
+          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: RISCOS-build/${{ needs.build-riscos.outputs.leafname }}
+          asset_name: ${{ needs.build-riscos.outputs.leafname }}
+          asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download built binary
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v8
         with:
           name: RISCOS-build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           echo "::set-output name=version::$version"
           echo "::set-output name=leafname::$leafname"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v7
         with:
           name: RISCOS-build
           path: ${{ steps.version.outputs.leafname }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,25 @@
+---
+# Automatically assign issues to users
+#
+# When new issues are created, they will automatically be assigned to a user.
+#
+
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  # See GitHub repository here: https://github.com/pozil/auto-assign-issue
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v2
+        with:
+          assignees: gerph
+          abortIfPreviousAssignees: true
+          allowSelfAssign: true

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
     steps:
       - name: Auto-assign issue
-        uses: pozil/auto-assign-issue@v2
+        uses: pozil/auto-assign-issue@v3.0.0
         with:
           assignees: gerph
           abortIfPreviousAssignees: true

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
     steps:
       - name: Auto-assign issue
-        uses: pozil/auto-assign-issue@v3.0.0
+        uses: pozil/auto-assign-issue@v4.0.1
         with:
           assignees: gerph
           abortIfPreviousAssignees: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+---
+# RISC OS CI build through build.riscos.online
+#
+# To reuse this configuration with your own repository:
+#
+#   - Create a .robuild.yaml to describe what should be built on RISC OS.
+#       - `jobs.build.script` should be a list of commands to run on RISC OS
+#       - `jobs.build.artifacts.path` should be the directory to zip.
+#   - Create a VersionNum file if you wish to use the automated versioning
+#     in the same style as the RISC OS sources. [optional]
+#   - Update the 2nd step ('give the archive a versioned name') to give a
+#     suitable name for the archive.
+#   - Update the artifacts path to include the same names.
+#
+
+
+riscos:
+    stage: build
+    script:
+      - |
+        set -o pipefail
+        # Zip up the source to send to robuild
+        zip -q9r /tmp/source-archive.zip * .robuild.yaml
+        # Fetch the build client
+        curl -s -L -o riscos-build-online https://github.com/gerph/robuild-client/releases/download/v0.05/riscos-build-online && chmod +x riscos-build-online
+        # Send the archive file to build service
+        ./riscos-build-online -i /tmp/source-archive.zip -t 60 -o /tmp/built
+
+      - |
+        if [[ -f VersionNum ]] ; then
+            version=$(sed '/MajorVersion / ! d ; s/.*MajorVersion *"\(.*\)"/\1/' VersionNum)
+        else
+            version=$(git rev-parse --short HEAD)
+        fi
+        echo "This is version: $version"
+        if [ -f /tmp/built,a91 ] ; then
+            cp /tmp/built,a91 "KeyMapper-$version.zip"
+        else
+            echo "No archive was built?"
+            exit 1
+        fi
+
+    artifacts:
+        when: always
+        paths:
+            - "KeyMapper-*.zip"
+
+    tags:
+      - linux
+
+stages:
+    - build

--- a/.robuild.yaml
+++ b/.robuild.yaml
@@ -1,0 +1,42 @@
+%YAML 1.0
+---
+
+# Example .robuild.yml file
+
+# Source is optional (NYI), and should be a URL to source the content from
+#source: <url>
+
+# Defines a list of jobs which will be performed.
+# Only 1 job will currently be executed.
+jobs:
+  build:
+    # Env defines system variables which will be used within the environment.
+    # Multiple variables may be assigned.
+    env:
+      "Sys$Environment": ROBuild
+      "BUILD32": 1
+
+    # Directory to change to before running script
+    #dir: <working directory>
+
+    # Commands which should be executed to perform the build.
+    # The build will terminate if any command returns a non-0 return code or an error.
+    script:
+      # Zip isn't present in the environment, but MiniZip is.
+      # But minizip doesn't take an '-r' switch, so we'll skip it.
+      # And we don't want a directory creating at the top level so we use -J.
+      - Set Alias$Zip MiniZip %0 -v %*2
+      - cdir hdr
+      - rename include/hdr hdr.include
+      - amu -f Makefile dist
+      # Although we create a zip archive inside the makefile, the build service
+      # takes the release directory and archives it itself.
+      # (limitation of the build service - only directories can be artifacted)
+
+    # Outputs from the build are defined in artifacts
+    # These are a list of artifacts to report directories or files.
+    # Only a single item is currently supported.
+    artifacts:
+      # Each element of the artifacts should have a path key, which gives the file or
+      # directory to return.
+      - path: Dist

--- a/.robuild.yaml
+++ b/.robuild.yaml
@@ -15,7 +15,6 @@ jobs:
     env:
       "Sys$Environment": ROBuild
       "BUILD32": 1
-      "Alias$ObjAsm": "HostObjAsm %*0"
 
     # Directory to change to before running script
     #dir: <working directory>

--- a/.robuild.yaml
+++ b/.robuild.yaml
@@ -15,6 +15,7 @@ jobs:
     env:
       "Sys$Environment": ROBuild
       "BUILD32": 1
+      "Alias$ObjAsm": "HostObjAsm %*0"
 
     # Directory to change to before running script
     #dir: <working directory>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+##
+# CODEOWNERS - define who is responsible for parts of the sources
+#
+# See:
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#   https://docs.gitlab.com/user/project/codeowners/reference/
+#
+
+# Default code owners - automatically assigned for reviews
+* @gerph

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ OBJS 	= module.o
 MODNAME = KeyMapper
 MODFILE = KeyMapper
 TGT  	= rm.$(MODFILE)
+RELEASEDIR = Dist
 ZIPDIST = keymapper/zip
 MODDIST = !System.350.Modules.$(MODFILE)
 INSTALL = <System$Dir>.350.Modules.$(MODFILE)
@@ -23,12 +24,22 @@ run: $(TGT)
 
 
 dist: $(TGT)
-	@echo Removing previous distribution archive...
-	@-wipe $(ZIPDIST) F~VR~C
+	@echo Removing previous distribution archive and directory...
+	@remove $(ZIPDIST)
+	@-wipe ${RELEASEDIR} F~VR~C
+	@echo Creating target directories
+	@cdir ${RELEASEDIR}
+	@cdir ${RELEASEDIR}.!System
+	@cdir ${RELEASEDIR}.!System.350
+	@cdir ${RELEASEDIR}.!System.350.Modules
 	@echo Copying $(TGT) to $(MODDIST)
-	@copy $(TGT) $(MODDIST) A~CF~L~N~P~QR~S~T~V
+	@copy $(TGT) ${RELEASEDIR}.$(MODDIST) A~CF~L~N~P~QR~S~T~V
+	@copy !ReadMe ${RELEASEDIR}.!ReadMe A~CF~L~N~P~QR~S~T~V
+	@copy LICENSE ${RELEASEDIR}.LICENSE A~CF~L~N~P~QR~S~T~V
 	@echo Zipping as $(ZIPDIST)...
-	@zip -9 -r $(ZIPDIST) $(DIST)
+	@dir ${RELEASEDIR}
+	@zip -9 -r \.$(ZIPDIST) $(DIST)
+	@back
 	@echo Done.
 
 clean:
@@ -36,8 +47,8 @@ clean:
 	@-wipe rm F~VR~C
 	@echo removing object files...
 	@-wipe o F~VR~C
-	@echo removing dist module...
-	@-wipe $(MODDIST)  F~VR~C
+	@echo removing dist directory...
+	@-wipe ${RELEASEDIR}  F~VR~C
 	@echo removing dist zip...
 	@-wipe $(ZIPDIST)  F~VR~C
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+    "forkProcessing": "enabled"
+}


### PR DESCRIPTION
This change introduces automated building of the sources using the
RISC OS Build service - we send the code and makefile to the service
and it builds things according to the makefile, and then returns the
result to us.

Every push to the repository will automatically build the code using
the `dist` target from the make file and archive the results as a RISC OS
zip archive.

We should also be able to create a tag prefixed with 'v' to create
a release automatically as well.